### PR TITLE
If does not guard fix.

### DIFF
--- a/src/shmem_quiet.c
+++ b/src/shmem_quiet.c
@@ -51,12 +51,12 @@ shmem_quiet(void)
 		);
 		// XXX This isn't a great way to guarantee the data has finished
 		if (__shmem.cdst0) {
-			if(*__shmem.cdst0 == __shmem.csrc0);
+			if(*__shmem.cdst0 == __shmem.csrc0)
 				*__shmem.cdst0 = ~__shmem.csrc0;
 			__shmem.cdst0 = 0;
 		}
 		if (__shmem.cdst1) {
-			if(*__shmem.cdst1 == __shmem.csrc1);
+			if(*__shmem.cdst1 == __shmem.csrc1)
 				*__shmem.cdst1 = ~__shmem.csrc1;
 			__shmem.cdst1 = 0;
 		}


### PR DESCRIPTION
At closer investigation this might be the desired implementation or the state will just flip-flop.
Resolves the compiler warning: If clause does not guard.

```make
shmem_quiet.c: In function ‘shmem_quiet’:
shmem_quiet.c:54:4: warning: this ‘if’ clause does not guard..
. [-Wmisleading-indentation]
    if(*__shmem.cdst0 == __shmem.csrc0);
    ^~
shmem_quiet.c:55:5: note: ...this statement, but the latter is
 misleadingly indented as if it were guarded by the ‘if’
     *__shmem.cdst0 = ~__shmem.csrc0;
     ^
shmem_quiet.c:59:4: warning: this ‘if’ clause does not guard..
. [-Wmisleading-indentation]
    if(*__shmem.cdst1 == __shmem.csrc1);
    ^~
shmem_quiet.c:60:5: note: ...this statement, but the latter is
 misleadingly indented as if it were guarded by the ‘if’
     *__shmem.cdst1 = ~__shmem.csrc1;
     ^
```